### PR TITLE
Atualizar cálculo de save

### DIFF
--- a/module/actor/entity.js
+++ b/module/actor/entity.js
@@ -153,7 +153,7 @@ export default class Actor5e extends Actor {
 			abl.mod = Math.floor((data.abilities[abl.ability].value - 10) / 2);
 			abl.prof = abl.proficient ? 3 + data.details.level : Math.floor(data.details.level / 2);
 			abl.saveBonus = saveBonus;
-			abl.save = abl.mod + abl.prof + abl.saveBonus;
+			abl.save = abl.mod + abl.prof + abl.saveBonus + abl.value;
 
 			// If we merged saves when transforming, take the highest bonus here.
 			if (originalSaves && abl.proficient) {


### PR DESCRIPTION
Como os outros campos dos saves são imutáveis (.saveBonus, .save, .mod e etc...), seria uma boa somar o campo 'value' ao save, visto que o campo .value é o único alterável por efeitos na ficha.

Dessa forma, podemos adicionar bônus nos saves utilizando efeitos ao invés de digitar manualmente do lado do save e ter que lembrar porque vc tem aquele bônus.